### PR TITLE
fix: addLiquidity token ratio

### DIFF
--- a/contracts/Exchange.sol
+++ b/contracts/Exchange.sol
@@ -43,10 +43,10 @@ contract Exchange is ERC20 {
         }
 
         IERC20 token = IERC20(tokenAddress);
-        token.transferFrom(msg.sender, address(this), _tokenAmount);
+        token.transferFrom(msg.sender, address(this), tokenAmount);
         _mint(msg.sender, liquidity);
 
-        emit AddLiquidity(msg.sender, msg.value, _tokenAmount);
+        emit AddLiquidity(msg.sender, msg.value, tokenAmount);
 
         return liquidity;
     }


### PR DESCRIPTION
Buenas, primero que nada muy bueno el curso muchas gracias.

Estoy siguiendo paso por paso lo que vas haciendo pero me llamó la atención la parte de mantener el ratio de token/ether en addliquidity.
Luego de pasar el check de que _tokenAmount >= correctTokenAmount se está  transfiriendo al contrato la cantidad de token que el usuario está enviando a la funcion addLiquidity.
Si no me equivoco esto estaría rompiendo el ratio token/ether en la pool.

Ejemplo: si el usuario envía 20 tokens, pero el correctTokenAmount da 15, lo correcto sería hacer un transfer al contrato de 15 y no de 20, "devolviendo" al usuario los 5 restantes para no romper con el ratio.

Saludos.